### PR TITLE
Add Rust project folder

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "kata"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,11 @@
+fn increment(i: i32) -> i32 {
+    return i + 1;
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn increment_adds_one() {
+        assert_eq!(super::increment(1), 2);
+    }
+}


### PR DESCRIPTION
Resolves #7. You'll need [rustup](https://rustup.rs/) to build this one.
```
$ cargo test
warning: function is never used: `increment`
 --> src/lib.rs:1:4
  |
1 | fn increment(i: i32) -> i32 {
  |    ^^^^^^^^^
  |
  = note: `#[warn(dead_code)]` on by default

warning: `kata` (lib) generated 1 warning
    Finished test [unoptimized + debuginfo] target(s) in 0.00s
     Running unittests (target/debug/deps/kata-802cfbbaa1ebd4d9)

running 1 test
test tests::increment_adds_one ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests kata

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```